### PR TITLE
Поправит баг с пробелом на Android

### DIFF
--- a/src/core/editor.js
+++ b/src/core/editor.js
@@ -21,8 +21,11 @@ const EDITOR_EVENTS = {
     click: require('./editor/click'),
     focus: require('./editor/focus'),
     keydown: require('./editor/keydown'),
-    keypress: require('./editor/keypress'),
-    keyup: require('./editor/keyup'),
+    keyup: function (event) {
+        require('./editor/keyup')(event);
+        // Событие `keypress` не работает на некоторых версиях Android.
+        require('./editor/keypress')(event);
+    },
     paste: require('./editor/paste'),
 };
 
@@ -30,7 +33,8 @@ const SELECT_EVENTS = {
     blur: require('./select/blur'),
     click: require('./select/click'),
     keydown: require('./select/keydown'),
-    keypress: require('./select/keypress'),
+    // Событие `keypress` не работает на некоторых версиях Android.
+    keyup: require('./select/keypress')
 };
 
 const PROXY_EVENTS = {

--- a/src/core/editor/keypress.js
+++ b/src/core/editor/keypress.js
@@ -1,4 +1,5 @@
 const events = require('../events');
+const utils = require('../utils');
 const bubble = require('../bubble');
 const cursor = require('../cursor');
 const { KEY } = require('../constant');
@@ -19,7 +20,9 @@ module.exports = function (event) {
 
     } else {
         const separator = nodeEditor.options('separator');
-        if (separator && separator.test(String.fromCharCode(code))) {
+        const inputChar = utils.getLastChar(event.target);
+
+        if (separator && (separator.test(String.fromCharCode(code)) || separator.test(inputChar))) {
             const separatorCond = nodeEditor.options('separatorCond');
 
             if (!separatorCond || separatorCond(nodeEditor.inputValue)) {

--- a/src/core/editor/keyup.js
+++ b/src/core/editor/keyup.js
@@ -7,12 +7,13 @@ const { KEY } = require('../constant');
 module.exports = function (event) {
     const nodeEditor = event.currentTarget;
     const code = events.keyCode(event);
+    const inputCharIsSpace = events.inputCharIsSpace(event);
     const isPrintableChar = do {
         if (event.key) {
             event.key.length === 1;
 
         } else {
-            ((code > 47 || code === KEY.Space || code === KEY.Backspace) && code !== KEY.Cmd);
+            ((code > 47 || code === KEY.Space || inputCharIsSpace || code === KEY.Backspace) && code !== KEY.Cmd);
         }
     };
 

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -2,6 +2,7 @@
  * @module x-bubbles/events
  */
 
+const utils = require('./utils');
 const context = require('../context');
 const CustomEventCommon = require('../polyfills/CustomEventCommon');
 const { PROPS } = require('./constant');
@@ -9,6 +10,11 @@ const { PROPS } = require('./constant');
 exports.scrollX = scrollX;
 exports.scrollY = scrollY;
 exports.dispatch = dispatch;
+exports.inputCharIs = inputCharIs;
+
+exports.inputCharIsSpace = function (event) {
+    return inputCharIs(event, ' ');
+};
 
 exports.keyCode = function (event) {
     return event.charCode || event.keyCode;
@@ -66,6 +72,10 @@ exports.prevent = function (event) {
 exports.proxyLocal = function (event) {
     dispatchLocalEvent(event.currentTarget, event);
 };
+
+function inputCharIs(event, char) {
+    return utils.getLastChar(event.target) === char;
+}
 
 function scrollX() {
     const html = context.document.documentElement;

--- a/src/core/select/keypress.js
+++ b/src/core/select/keypress.js
@@ -9,6 +9,7 @@ const { KEY } = require('../constant');
  */
 module.exports = function (event) {
     const code = events.keyCode(event);
+    const inputCharIsSpace = events.inputCharIsSpace(event);
     const nodeEditor = event.currentTarget;
 
     if (code === KEY.Enter) {
@@ -17,7 +18,7 @@ module.exports = function (event) {
             editBubbleKeyboardEvent(nodeEditor);
         }
 
-    } else if (code === KEY.Space) {
+    } else if (code === KEY.Space || inputCharIsSpace) {
         if (editBubbleKeyboardEvent(nodeEditor)) {
             event.preventDefault();
         }

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -30,6 +30,12 @@ const REG_HAS_UNESCAPED_HTML = RegExp(REG_UNESCAPED_HTML.source);
 const REG_IE = /Trident|Edge/;
 const REG_MOBILE_IE = /IEMobile/;
 
+exports.getLastChar = function (node) {
+    const content = node.textContent;
+
+    return content.charAt(content.length - 1);
+};
+
 exports.getSelection = function (nodeEditor) {
     const selection = context.getSelection();
 


### PR DESCRIPTION
#### Что сделано?

Некоторые клавиатуры Android не отправляют key code для специальных клавиш (Backspace, Spacebar, Enter и тп).
Добавил проверку последнего символа в элементе на пробел в добавок к проверке key code.

Воспроизводилось на `ASUS ZenFone 5/8.0 + GBoard`